### PR TITLE
Feat: MongoDB Album Document에 관한 MVC 레이어 및 커스텀 컨버터 추가

### DIFF
--- a/src/main/java/org/example/luvbackend/common/entity/BaseEntity.java
+++ b/src/main/java/org/example/luvbackend/common/entity/BaseEntity.java
@@ -1,0 +1,16 @@
+package org.example.luvbackend.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseEntity {
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	// @LastModifiedDate
+	// private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/example/luvbackend/config/MongoConverterConfig.java
+++ b/src/main/java/org/example/luvbackend/config/MongoConverterConfig.java
@@ -1,0 +1,32 @@
+package org.example.luvbackend.config;
+
+import java.util.List;
+
+import org.example.luvbackend.entity.album.AlbumType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+@Configuration
+public class MongoConverterConfig {
+	@Bean
+	public MongoCustomConversions mongoCustomConversions() {
+		return new MongoCustomConversions(List.of(
+			// DB -> Enum
+			new Converter<String, AlbumType>() {
+				@Override
+				public AlbumType convert(String albumType) {
+					return AlbumType.deserialize(albumType);
+				}
+			},
+			// Enum -> DB
+			new Converter<AlbumType, String>() {
+				@Override
+				public String convert(AlbumType albumType) {
+					return albumType.getValue();
+				}
+			}
+		));
+	}
+}

--- a/src/main/java/org/example/luvbackend/controller/album/AlbumController.java
+++ b/src/main/java/org/example/luvbackend/controller/album/AlbumController.java
@@ -1,0 +1,23 @@
+package org.example.luvbackend.controller.album;
+
+import java.util.List;
+
+import org.example.luvbackend.dto.AlbumResponseDto;
+import org.example.luvbackend.service.AlbumService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/albums")
+@RequiredArgsConstructor
+public class AlbumController {
+	private final AlbumService albumService;
+
+	@GetMapping
+	public List<AlbumResponseDto> getAlbums() {
+		return albumService.getAlbums();
+	}
+}

--- a/src/main/java/org/example/luvbackend/dto/AlbumResponseDto.java
+++ b/src/main/java/org/example/luvbackend/dto/AlbumResponseDto.java
@@ -1,0 +1,21 @@
+package org.example.luvbackend.dto;
+
+import org.example.luvbackend.entity.album.Album;
+
+import lombok.Getter;
+
+@Getter
+public class AlbumResponseDto {
+	private final String title;
+	private final String date;
+	private final String albumType;
+	private final String[] imgUrls;
+	// createdAt 넣어야 함
+
+	public AlbumResponseDto(Album album){
+		this.title = album.getTitle();
+		this.date = album.getDate();
+		this.albumType = album.getType();
+		this.imgUrls = album.getImgUrls();
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/album/Album.java
+++ b/src/main/java/org/example/luvbackend/entity/album/Album.java
@@ -1,0 +1,25 @@
+package org.example.luvbackend.entity.album;
+
+import org.example.luvbackend.common.entity.BaseEntity;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "albums")
+@Getter
+@NoArgsConstructor
+public class Album extends BaseEntity {
+	@Id
+	private String id;
+
+	private String title;
+	private String date;
+	private AlbumType type;
+	private String[] imgUrls;
+
+	public String getType() {
+		return type.getValue();
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/album/AlbumType.java
+++ b/src/main/java/org/example/luvbackend/entity/album/AlbumType.java
@@ -1,0 +1,43 @@
+package org.example.luvbackend.entity.album;
+
+import org.example.luvbackend.exception.album.AlbumException;
+import org.example.luvbackend.exception.album.AlbumExceptionCode;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AlbumType {
+	ALL("all"),
+	MAIN("main"),
+	INFANTS("infants"),
+	TODDLERS("toddlers"),
+	ELEMENTARY("elementary"),
+	MIDDLE("middle"),
+	HIGH("high"),
+	YOUTH("youth"),
+	QT("qt"),
+	PANORAMA("panorama"),
+	NEW_FAMILY("newFamily"),
+	NEWLY_WEDDINGS("newlyweds"),
+	GEN_3040("3040");
+
+	private final String value;
+
+	@JsonValue
+	public String getValue(){
+		return value;
+	}
+
+	@JsonCreator
+	public static AlbumType deserialize(String fromDB){
+		for(AlbumType albumType : AlbumType.values()){
+			if(albumType.getValue().equalsIgnoreCase(fromDB)){
+				return albumType;
+			}
+		}
+		throw new AlbumException(AlbumExceptionCode.ILLEGAL_ALBUM_TYPE);
+	}
+}

--- a/src/main/java/org/example/luvbackend/exception/BaseException.java
+++ b/src/main/java/org/example/luvbackend/exception/BaseException.java
@@ -1,0 +1,9 @@
+package org.example.luvbackend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class BaseException extends RuntimeException {
+	public abstract Enum<?> getErrorCode();
+	public abstract HttpStatus getHttpStatus();
+	public abstract String getMessage();
+}

--- a/src/main/java/org/example/luvbackend/exception/album/AlbumException.java
+++ b/src/main/java/org/example/luvbackend/exception/album/AlbumException.java
@@ -1,0 +1,20 @@
+package org.example.luvbackend.exception.album;
+
+import org.example.luvbackend.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class AlbumException extends BaseException {
+	private final AlbumExceptionCode errorCode;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public AlbumException(AlbumExceptionCode errorCode) {
+		this.errorCode = errorCode;
+		this.httpStatus = errorCode.getHttpStatus();
+		this.message = errorCode.getMessage();
+	}
+}
+

--- a/src/main/java/org/example/luvbackend/exception/album/AlbumExceptionCode.java
+++ b/src/main/java/org/example/luvbackend/exception/album/AlbumExceptionCode.java
@@ -1,0 +1,16 @@
+package org.example.luvbackend.exception.album;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlbumExceptionCode {
+	ILLEGAL_ALBUM_TYPE(false, HttpStatus.BAD_REQUEST, "존재하지 않는 앨범타입입니다.");
+
+	private final boolean isSuccess;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/example/luvbackend/repository/AlbumRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/AlbumRepository.java
@@ -1,0 +1,9 @@
+package org.example.luvbackend.repository;
+
+import org.example.luvbackend.entity.album.Album;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlbumRepository extends MongoRepository<Album, String> {
+}

--- a/src/main/java/org/example/luvbackend/service/AlbumService.java
+++ b/src/main/java/org/example/luvbackend/service/AlbumService.java
@@ -1,0 +1,21 @@
+package org.example.luvbackend.service;
+
+import java.util.List;
+
+import org.example.luvbackend.dto.AlbumResponseDto;
+import org.example.luvbackend.repository.AlbumRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumService {
+	private final AlbumRepository albumRepository;
+
+	public List<AlbumResponseDto> getAlbums() {
+		return albumRepository.findAll()
+			.stream().map(AlbumResponseDto::new)
+			.toList();
+	}
+}


### PR DESCRIPTION
## 변경 사항

- 앨범 엔티티/도큐먼트 추가
- 앨범 MVC 레이어 추가 (Controller, Service, Repository, DTO)
- 앨범 예외(Exception) 추가
- **앨범 커스텀 컨버터** 추가

---

## 트러블 슈팅

### Enum 매핑 오류 발생
```
No enum constant org.example.luvbackend.entity.AlbumType.main
```
- 몽고DB와 스프링 사이에는 `Spring Data MongoDB(Object-Document Mapper)`를 사용
- 내부적으로 `MappingMongoConverter`를 사용하여 자바객체로 매핑한다.
- Enum의 경우, `Enum.name()`를 갖고 매핑하는게 기본 전략
- 해당 전략을 바꿀 수 없기 때문에 `MongoCustomConversions`의 커스텀 컨버터 추가

---

## 참고 사항

- `MongoCustomConversions`의 커스텀 컨버터 추가
  - Hibernate의 AttributeConverter 같은 역할이라고 함



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 앨범 목록 조회 API 추가: 제목, 날짜, 유형, 이미지 URL을 포함한 앨범 정보를 반환합니다.
  - 앨범 유형 처리 개선: DB 문자열과 앱 내 유형 간 자동 변환으로 일관된 응답을 제공합니다.
  - 오류 응답 고도화: 유효하지 않은 앨범 유형 요청 시 명확한 메시지와 적절한 상태 코드를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->