### PR TITLE
Chore: 환경변수 설정을 AWS-Parameter-Store로 마이그레이션

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,12 +7,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      MONGO_PW: ${{ secrets.MONGO_PW }}
-      MONGO_DBNAME: ${{ secrets.MONGO_DBNAME }}
-      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-      AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
-      AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -39,17 +33,10 @@ jobs:
 
       - name: EC2 실행
         uses: appleboy/ssh-action@master
-        env:
-          MONGO_PW: ${{ secrets.MONGO_PW }}
-          MONGO_DBNAME: ${{ secrets.MONGO_DBNAME }}
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          envs: MONGO_PW,MONGO_DBNAME,AWS_S3_BUCKET,AWS_S3_ACCESS_KEY,AWS_S3_SECRET_KEY
           script: |
             pkill -f 'java -jar' || true
             sleep 3

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,12 @@ repositories {
 // CVE-2025-48924: commons-lang3 < 3.18.0 DoS 취약점 대응
 ext['commons-lang3.version'] = '3.18.0'
 
+dependencyManagement {
+    imports {
+        mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:3.4.0"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -35,6 +41,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.2'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/example/luvbackend/config/AwsS3Config.java
+++ b/src/main/java/org/example/luvbackend/config/AwsS3Config.java
@@ -4,29 +4,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class AwsS3Config {
 
-	@Value("${spring.cloud.aws.credentials.access-key}")
-	private String accessKey;
-
-	@Value("${spring.cloud.aws.credentials.secret-key}")
-	private String secretKey;
-
 	@Value("${spring.cloud.aws.region.static}")
 	private String region;
 
 	@Bean
 	public S3Client awsS3Client() {
-		AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 		return S3Client.builder()
 			.region(Region.of(region))
-			.credentialsProvider(StaticCredentialsProvider.create(credentials))
+			.credentialsProvider(InstanceProfileCredentialsProvider.create()) // EC2에 지정된 IAM Role 가져오기
 			.build();
 	}
 }

--- a/src/main/java/org/example/luvbackend/config/AwsS3Config.java
+++ b/src/main/java/org/example/luvbackend/config/AwsS3Config.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -18,7 +18,7 @@ public class AwsS3Config {
 	public S3Client awsS3Client() {
 		return S3Client.builder()
 			.region(Region.of(region))
-			.credentialsProvider(InstanceProfileCredentialsProvider.create()) // EC2에 지정된 IAM Role 가져오기
+			.credentialsProvider(DefaultCredentialsProvider.create()) // 로컬에서 application-local, 운영에선 EC2에 지정된 IAM Role 가져오기
 			.build();
 	}
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,16 +11,6 @@ spring:
   config:
     import: aws-parameterstore:/luv-backend/prod/ # AWS-parameter-store 경로 설정
 
-  datasource:
-    hikari:
-      maximum-pool-size: 10    # DB 커넥션 최대 10개 유지
-      minimum-idle: 3          # 유휴 상태에서도 최소 3개 유지
-      connection-timeout: 30000   # 커넥션 못 얻으면 30초 후 에러
-      idle-timeout: 600000        # 놀고 있는 커넥션 10분 후 반납
-      max-lifetime: 1800000       # 커넥션 최대 수명 30분 (DB 강제 종료 방지)
-  jpa:
-    open-in-view: false         # 커넥션 점유 방지
-
   # 불필요한 자동설정 제외: JMX(Java Management Extensions) 관리 빈 자동 생성을 비활성화
   autoconfigure:
     exclude:
@@ -34,13 +24,8 @@ spring:
   ## AWS
   cloud:
     aws:
-      parameterstore:
-        region: ap-northeast-2
       ## IMAGE 업로드 버킷
       s3:
         bucket: ${AWS_S3_BUCKET}
-      credentials:
-        access-key: ${AWS_S3_ACCESS_KEY}
-        secret-key: ${AWS_S3_SECRET_KEY}
       region:
         static: ap-northeast-2

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,6 +8,9 @@ server:
     connection-timeout: 5000  # 5초 안에 요청 안오면 연결 끊음
 
 spring:
+  config:
+    import: aws-parameterstore:/luv-backend/prod/ # AWS-parameter-store 경로 설정
+
   datasource:
     hikari:
       maximum-pool-size: 10    # DB 커넥션 최대 10개 유지
@@ -17,8 +20,6 @@ spring:
       max-lifetime: 1800000       # 커넥션 최대 수명 30분 (DB 강제 종료 방지)
   jpa:
     open-in-view: false         # 커넥션 점유 방지
-    hibernate:
-      ddl-auto: validate
 
   # 불필요한 자동설정 제외: JMX(Java Management Extensions) 관리 빈 자동 생성을 비활성화
   autoconfigure:
@@ -33,6 +34,8 @@ spring:
   ## AWS
   cloud:
     aws:
+      parameterstore:
+        region: ap-northeast-2
       ## IMAGE 업로드 버킷
       s3:
         bucket: ${AWS_S3_BUCKET}


### PR DESCRIPTION
## 변경 사항

- `build.gradle`: Parameter Store 의존성 → awspring 3.x로 교체
- `deploy.yml`: 앱 시크릿 환경변수 전부 제거 (EC2 IAM Role + Parameter Store로 대체)                                                                           
- `application-prod.yml`: 불필요한 datasource/jpa 제거, credentials 제거 (IAM Role로 대체)
- `AwsS3Config`: 환경변수로 받던 S3 접근키를 EC2 IAM Role로 대체

---

## 트러블 슈팅

- `InstanceProfileCredentialsProvider`를 사용하면 EC2 IAM Role만 가져옴
  - `DefaultCredentialsProvider`를 사용하면 로컬/운영환경에서 함께 사용 가능
- AWS 배포 환경변수 설정시 AWS-Parameter-Store 사용

---

## 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.

---

## 참고 사항

- 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* AWS Parameter Store를 통해 프로덕션 환경 설정을 관리하도록 변경했습니다. 데이터베이스 및 클라우드 자격증명이 더 이상 설정 파일에 포함되지 않습니다.
* 배포 워크플로우에서 환경 변수 주입 방식을 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->