### PR TITLE
Feat: 담임목사님 관련/사용자 페이지 메인 API 추가 및 조회방법 dateDesc로 변경

### DIFF
--- a/src/main/java/org/example/luvbackend/controller/homeContent/HomeContentController.java
+++ b/src/main/java/org/example/luvbackend/controller/homeContent/HomeContentController.java
@@ -1,0 +1,76 @@
+package org.example.luvbackend.controller.homeContent;
+
+import org.example.luvbackend.common.dto.ApiResponse;
+import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.dto.homeimage.HomeImageResponseDto;
+import org.example.luvbackend.dto.homeyoutube.HomeYoutubeForm;
+import org.example.luvbackend.dto.homeyoutube.HomeYoutubeResponseDto;
+import org.example.luvbackend.service.HomeImageService;
+import org.example.luvbackend.service.HomeYoutubeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/home-content")
+@RequiredArgsConstructor
+public class HomeContentController {
+	private final HomeYoutubeService homeYoutubeService;
+	private final HomeImageService homeImageService;
+
+	@Operation(summary = "홈 유튜브 링크 조회")
+	@GetMapping("/youtube")
+	public ApiResponse<HomeYoutubeResponseDto> getHomeYoutube() {
+		return ApiResponse.success(homeYoutubeService.getHomeYoutube());
+	}
+
+	@Operation(summary = "홈 유튜브 링크 수정")
+	@PatchMapping("/youtube")
+	public ApiResponse<HomeYoutubeResponseDto> updateHomeYoutube(
+		@RequestBody @Valid HomeYoutubeForm form
+	) {
+		return ApiResponse.success(homeYoutubeService.updateHomeYoutube(form));
+	}
+
+	@Operation(summary = "홈 이미지 목록 조회")
+	@GetMapping("/images")
+	public ApiResponse<PageResponse<HomeImageResponseDto>> getHomeImages(
+		@RequestParam(name = "page", defaultValue = "0") int page,
+		@RequestParam(name = "size", defaultValue = "10") int size
+	) {
+		return ApiResponse.success(homeImageService.getHomeImages(page, size));
+	}
+
+	@Operation(summary = "홈 이미지 추가")
+	@PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<HomeImageResponseDto> createHomeImage(
+		@RequestParam("image") MultipartFile image
+	) {
+		return ApiResponse.created(homeImageService.createHomeImage(image));
+	}
+
+	@Operation(summary = "홈 이미지 삭제")
+	@DeleteMapping("/images/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public ApiResponse<Void> deleteHomeImage(
+		@PathVariable(name = "id") String id
+	) {
+		homeImageService.deleteHomeImage(id);
+		return ApiResponse.noContent();
+	}
+}

--- a/src/main/java/org/example/luvbackend/controller/pastorbook/PastorBookController.java
+++ b/src/main/java/org/example/luvbackend/controller/pastorbook/PastorBookController.java
@@ -1,0 +1,67 @@
+package org.example.luvbackend.controller.pastorbook;
+
+import org.example.luvbackend.common.dto.ApiResponse;
+import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.dto.pastorbook.PastorBookForm;
+import org.example.luvbackend.dto.pastorbook.PastorBookResponseDto;
+import org.example.luvbackend.service.PastorBookService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/pastor/books")
+@RequiredArgsConstructor
+public class PastorBookController {
+	private final PastorBookService pastorBookService;
+
+	@Operation(summary = "담임목사 저서 목록 조회")
+	@GetMapping
+	public ApiResponse<PageResponse<PastorBookResponseDto>> getPastorBooks(
+		@RequestParam(name = "page", defaultValue = "0") int page,
+		@RequestParam(name = "size", defaultValue = "10") int size
+	) {
+		return ApiResponse.success(pastorBookService.getPastorBooks(page, size));
+	}
+
+	@Operation(summary = "담임목사 저서 생성")
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<PastorBookResponseDto> createPastorBook(
+		@ModelAttribute @Valid PastorBookForm form
+	) {
+		return ApiResponse.created(pastorBookService.createPastorBook(form));
+	}
+
+	@Operation(summary = "담임목사 저서 수정")
+	@PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ApiResponse<PastorBookResponseDto> updatePastorBook(
+		@PathVariable(name = "id") String id,
+		@ModelAttribute @Valid PastorBookForm form
+	) {
+		return ApiResponse.success(pastorBookService.updatePastorBook(id, form));
+	}
+
+	@Operation(summary = "담임목사 저서 삭제")
+	@DeleteMapping("/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public ApiResponse<Void> deletePastorBook(
+		@PathVariable(name = "id") String id
+	) {
+		pastorBookService.deletePastorBook(id);
+		return ApiResponse.noContent();
+	}
+}

--- a/src/main/java/org/example/luvbackend/controller/pastorbook/PastorBookController.java
+++ b/src/main/java/org/example/luvbackend/controller/pastorbook/PastorBookController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -47,7 +47,7 @@ public class PastorBookController {
 	}
 
 	@Operation(summary = "담임목사 저서 수정")
-	@PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ApiResponse<PastorBookResponseDto> updatePastorBook(
 		@PathVariable(name = "id") String id,
 		@ModelAttribute @Valid PastorBookForm form

--- a/src/main/java/org/example/luvbackend/controller/pastorprofileimage/PastorProfileImageController.java
+++ b/src/main/java/org/example/luvbackend/controller/pastorprofileimage/PastorProfileImageController.java
@@ -7,7 +7,7 @@ import org.example.luvbackend.service.PastorProfileImageService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,7 +27,7 @@ public class PastorProfileImageController {
 	}
 
 	@Operation(summary = "담임목사 프로필 이미지 수정")
-	@PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ApiResponse<PastorProfileImageResponseDto> updatePastorProfileImage(
 		@ModelAttribute PastorProfileImageForm form
 	) {

--- a/src/main/java/org/example/luvbackend/controller/pastorprofileimage/PastorProfileImageController.java
+++ b/src/main/java/org/example/luvbackend/controller/pastorprofileimage/PastorProfileImageController.java
@@ -1,0 +1,36 @@
+package org.example.luvbackend.controller.pastorprofileimage;
+
+import org.example.luvbackend.common.dto.ApiResponse;
+import org.example.luvbackend.dto.pastorprofileimage.PastorProfileImageForm;
+import org.example.luvbackend.dto.pastorprofileimage.PastorProfileImageResponseDto;
+import org.example.luvbackend.service.PastorProfileImageService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/pastor/profile")
+@RequiredArgsConstructor
+public class PastorProfileImageController {
+	private final PastorProfileImageService pastorProfileImageService;
+
+	@Operation(summary = "담임목사 프로필 이미지 조회")
+	@GetMapping
+	public ApiResponse<PastorProfileImageResponseDto> getPastorProfileImage() {
+		return ApiResponse.success(pastorProfileImageService.getPastorProfileImage());
+	}
+
+	@Operation(summary = "담임목사 프로필 이미지 수정")
+	@PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ApiResponse<PastorProfileImageResponseDto> updatePastorProfileImage(
+		@ModelAttribute PastorProfileImageForm form
+	) {
+		return ApiResponse.success(pastorProfileImageService.updatePastorProfileImage(form));
+	}
+}

--- a/src/main/java/org/example/luvbackend/dto/aws/S3Directory.java
+++ b/src/main/java/org/example/luvbackend/dto/aws/S3Directory.java
@@ -11,7 +11,8 @@ public enum S3Directory {
 	BULLETINS("bulletins"),
 	HOMEWORSHIPS("homeworships"),
 	MISSION_NEWS("missionNewsList"),
-	POPUPS("popups");
+	POPUPS("popups"),
+	LEADERSHIP("leadership");
 
 	private final String path;
 }

--- a/src/main/java/org/example/luvbackend/dto/aws/S3Directory.java
+++ b/src/main/java/org/example/luvbackend/dto/aws/S3Directory.java
@@ -12,7 +12,8 @@ public enum S3Directory {
 	HOMEWORSHIPS("homeworships"),
 	MISSION_NEWS("missionNewsList"),
 	POPUPS("popups"),
-	LEADERSHIP("leadership");
+	LEADERSHIP("leadership"),
+	HOME_IMAGES("homeContent/images");
 
 	private final String path;
 }

--- a/src/main/java/org/example/luvbackend/dto/homeimage/HomeImageResponseDto.java
+++ b/src/main/java/org/example/luvbackend/dto/homeimage/HomeImageResponseDto.java
@@ -1,0 +1,18 @@
+package org.example.luvbackend.dto.homeimage;
+
+import org.example.luvbackend.entity.homeimage.HomeImage;
+
+import lombok.Getter;
+
+@Getter
+public class HomeImageResponseDto {
+	private final String id;
+	private final String imageUrl;
+	private final Long createdAt;
+
+	public HomeImageResponseDto(HomeImage homeImage) {
+		this.id = homeImage.getId();
+		this.imageUrl = homeImage.getImageUrl();
+		this.createdAt = homeImage.getCreatedAt();
+	}
+}

--- a/src/main/java/org/example/luvbackend/dto/homeyoutube/HomeYoutubeForm.java
+++ b/src/main/java/org/example/luvbackend/dto/homeyoutube/HomeYoutubeForm.java
@@ -1,0 +1,14 @@
+package org.example.luvbackend.dto.homeyoutube;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class HomeYoutubeForm {
+	@NotBlank(message = "유튜브 링크를 입력해주세요.")
+	private String youtubeUrl;
+}

--- a/src/main/java/org/example/luvbackend/dto/homeyoutube/HomeYoutubeResponseDto.java
+++ b/src/main/java/org/example/luvbackend/dto/homeyoutube/HomeYoutubeResponseDto.java
@@ -1,0 +1,14 @@
+package org.example.luvbackend.dto.homeyoutube;
+
+import org.example.luvbackend.entity.homeyoutube.HomeYoutube;
+
+import lombok.Getter;
+
+@Getter
+public class HomeYoutubeResponseDto {
+	private final String youtubeUrl;
+
+	public HomeYoutubeResponseDto(HomeYoutube homeYoutube) {
+		this.youtubeUrl = homeYoutube.getYoutubeUrl();
+	}
+}

--- a/src/main/java/org/example/luvbackend/dto/pastorbook/PastorBookForm.java
+++ b/src/main/java/org/example/luvbackend/dto/pastorbook/PastorBookForm.java
@@ -1,0 +1,26 @@
+package org.example.luvbackend.dto.pastorbook;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PastorBookForm {
+	@NotBlank(message = "제목은 필수 입력값입니다.")
+	private String title;
+
+	private String sub;
+
+	@NotBlank(message = "출판사는 필수 입력값입니다.")
+	private String publisher;
+
+	@NotBlank(message = "출판연도는 필수 입력값입니다.")
+	private String year;
+
+	private MultipartFile image;
+}

--- a/src/main/java/org/example/luvbackend/dto/pastorbook/PastorBookResponseDto.java
+++ b/src/main/java/org/example/luvbackend/dto/pastorbook/PastorBookResponseDto.java
@@ -1,0 +1,26 @@
+package org.example.luvbackend.dto.pastorbook;
+
+import org.example.luvbackend.entity.pastorbook.PastorBook;
+
+import lombok.Getter;
+
+@Getter
+public class PastorBookResponseDto {
+	private final String id;
+	private final String title;
+	private final String sub;
+	private final String publisher;
+	private final String year;
+	private final String imageUrl;
+	private final Long createdAt;
+
+	public PastorBookResponseDto(PastorBook pastorBook) {
+		this.id = pastorBook.getId();
+		this.title = pastorBook.getTitle();
+		this.sub = pastorBook.getSub();
+		this.publisher = pastorBook.getPublisher();
+		this.year = pastorBook.getYear();
+		this.imageUrl = pastorBook.getImageUrl();
+		this.createdAt = pastorBook.getCreatedAt();
+	}
+}

--- a/src/main/java/org/example/luvbackend/dto/pastorprofileimage/PastorProfileImageForm.java
+++ b/src/main/java/org/example/luvbackend/dto/pastorprofileimage/PastorProfileImageForm.java
@@ -1,0 +1,15 @@
+package org.example.luvbackend.dto.pastorprofileimage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PastorProfileImageForm {
+	private MultipartFile topImage;
+	private MultipartFile bottomImage;
+}

--- a/src/main/java/org/example/luvbackend/dto/pastorprofileimage/PastorProfileImageResponseDto.java
+++ b/src/main/java/org/example/luvbackend/dto/pastorprofileimage/PastorProfileImageResponseDto.java
@@ -1,0 +1,16 @@
+package org.example.luvbackend.dto.pastorprofileimage;
+
+import org.example.luvbackend.entity.pastorprofileimage.PastorProfileImage;
+
+import lombok.Getter;
+
+@Getter
+public class PastorProfileImageResponseDto {
+	private final String topImageUrl;
+	private final String bottomImageUrl;
+
+	public PastorProfileImageResponseDto(PastorProfileImage pastorProfileImage) {
+		this.topImageUrl = pastorProfileImage.getTopImageUrl();
+		this.bottomImageUrl = pastorProfileImage.getBottomImageUrl();
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/homeimage/HomeImage.java
+++ b/src/main/java/org/example/luvbackend/entity/homeimage/HomeImage.java
@@ -1,0 +1,23 @@
+package org.example.luvbackend.entity.homeimage;
+
+import org.example.luvbackend.common.entity.BaseEntity;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "home_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HomeImage extends BaseEntity {
+	@Id
+	private String id;
+
+	private String imageUrl;
+
+	public HomeImage(String imageUrl) {
+		this.imageUrl = imageUrl;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/homeyoutube/HomeYoutube.java
+++ b/src/main/java/org/example/luvbackend/entity/homeyoutube/HomeYoutube.java
@@ -1,0 +1,28 @@
+package org.example.luvbackend.entity.homeyoutube;
+
+import org.example.luvbackend.common.entity.BaseEntity;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "homeYoutube")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HomeYoutube extends BaseEntity {
+	@Id
+	private String id = "home_youtube";
+
+	private String youtubeUrl;
+
+	public HomeYoutube(String youtubeUrl) {
+		this.id = "home_youtube";
+		this.youtubeUrl = youtubeUrl;
+	}
+
+	public void updateYoutubeUrl(String youtubeUrl) {
+		this.youtubeUrl = youtubeUrl;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/pastorbook/PastorBook.java
+++ b/src/main/java/org/example/luvbackend/entity/pastorbook/PastorBook.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Document(collection = "pastor_books")
+@Document(collection = "pastorBooks")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PastorBook extends BaseEntity {

--- a/src/main/java/org/example/luvbackend/entity/pastorbook/PastorBook.java
+++ b/src/main/java/org/example/luvbackend/entity/pastorbook/PastorBook.java
@@ -1,0 +1,52 @@
+package org.example.luvbackend.entity.pastorbook;
+
+import org.example.luvbackend.common.entity.BaseEntity;
+import org.example.luvbackend.dto.pastorbook.PastorBookForm;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "pastor_books")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PastorBook extends BaseEntity {
+	@Id
+	private String id;
+
+	private String title;
+	private String sub;
+	private String publisher;
+	private String year;
+	private String imageUrl;
+
+	@Builder
+	private PastorBook(String title, String sub, String publisher, String year, String imageUrl) {
+		this.title = title;
+		this.sub = sub;
+		this.publisher = publisher;
+		this.year = year;
+		this.imageUrl = imageUrl;
+	}
+
+	public static PastorBook from(PastorBookForm form, String imageUrl) {
+		return PastorBook.builder()
+			.title(form.getTitle())
+			.sub(form.getSub())
+			.publisher(form.getPublisher())
+			.year(form.getYear())
+			.imageUrl(imageUrl)
+			.build();
+	}
+
+	public void update(PastorBookForm form, String imageUrl) {
+		this.title = form.getTitle();
+		this.sub = form.getSub();
+		this.publisher = form.getPublisher();
+		this.year = form.getYear();
+		if (imageUrl != null) this.imageUrl = imageUrl;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/pastorprofile/PastorProfile.java
+++ b/src/main/java/org/example/luvbackend/entity/pastorprofile/PastorProfile.java
@@ -1,0 +1,34 @@
+package org.example.luvbackend.entity.pastorprofile;
+
+import org.example.luvbackend.common.entity.BaseEntity;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "pastor_profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PastorProfile extends BaseEntity {
+	@Id
+	private String id = "pastor-profile";
+
+	private String topImageUrl;
+	private String bottomImageUrl;
+
+	public PastorProfile(String topImageUrl, String bottomImageUrl) {
+		this.id = "pastor-profile";
+		this.topImageUrl = topImageUrl;
+		this.bottomImageUrl = bottomImageUrl;
+	}
+
+	public void updateTopImageUrl(String topImageUrl) {
+		this.topImageUrl = topImageUrl;
+	}
+
+	public void updateBottomImageUrl(String bottomImageUrl) {
+		this.bottomImageUrl = bottomImageUrl;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/pastorprofileimage/PastorProfileImage.java
+++ b/src/main/java/org/example/luvbackend/entity/pastorprofileimage/PastorProfileImage.java
@@ -1,4 +1,4 @@
-package org.example.luvbackend.entity.pastorprofile;
+package org.example.luvbackend.entity.pastorprofileimage;
 
 import org.example.luvbackend.common.entity.BaseEntity;
 import org.springframework.data.annotation.Id;
@@ -8,18 +8,18 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Document(collection = "pastor_profile")
+@Document(collection = "pastor_profile_image")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PastorProfile extends BaseEntity {
+public class PastorProfileImage extends BaseEntity {
 	@Id
-	private String id = "pastor-profile";
+	private String id = "pastor-profile-image";
 
 	private String topImageUrl;
 	private String bottomImageUrl;
 
-	public PastorProfile(String topImageUrl, String bottomImageUrl) {
-		this.id = "pastor-profile";
+	public PastorProfileImage(String topImageUrl, String bottomImageUrl) {
+		this.id = "pastor-profile-image";
 		this.topImageUrl = topImageUrl;
 		this.bottomImageUrl = bottomImageUrl;
 	}

--- a/src/main/java/org/example/luvbackend/exception/homeimage/HomeImageException.java
+++ b/src/main/java/org/example/luvbackend/exception/homeimage/HomeImageException.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.exception.homeimage;
+
+import org.example.luvbackend.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class HomeImageException extends BaseException {
+	private final HomeImageExceptionCode errorCode;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public HomeImageException(HomeImageExceptionCode errorCode) {
+		this.errorCode = errorCode;
+		this.httpStatus = errorCode.getHttpStatus();
+		this.message = errorCode.getMessage();
+	}
+}

--- a/src/main/java/org/example/luvbackend/exception/homeimage/HomeImageExceptionCode.java
+++ b/src/main/java/org/example/luvbackend/exception/homeimage/HomeImageExceptionCode.java
@@ -1,0 +1,17 @@
+package org.example.luvbackend.exception.homeimage;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum HomeImageExceptionCode {
+	NOT_FOUND_HOME_IMAGE(false, HttpStatus.NOT_FOUND, "홈 이미지를 찾을 수 없습니다."),
+	NO_IMAGE_PROVIDED(false, HttpStatus.BAD_REQUEST, "이미지를 업로드해주세요.");
+
+	private final boolean isSuccess;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/example/luvbackend/exception/homeyoutube/HomeYoutubeException.java
+++ b/src/main/java/org/example/luvbackend/exception/homeyoutube/HomeYoutubeException.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.exception.homeyoutube;
+
+import org.example.luvbackend.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class HomeYoutubeException extends BaseException {
+	private final HomeYoutubeExceptionCode errorCode;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public HomeYoutubeException(HomeYoutubeExceptionCode errorCode) {
+		this.errorCode = errorCode;
+		this.httpStatus = errorCode.getHttpStatus();
+		this.message = errorCode.getMessage();
+	}
+}

--- a/src/main/java/org/example/luvbackend/exception/homeyoutube/HomeYoutubeExceptionCode.java
+++ b/src/main/java/org/example/luvbackend/exception/homeyoutube/HomeYoutubeExceptionCode.java
@@ -1,0 +1,16 @@
+package org.example.luvbackend.exception.homeyoutube;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum HomeYoutubeExceptionCode {
+	NOT_FOUND_HOME_YOUTUBE(false, HttpStatus.NOT_FOUND, "홈 유튜브 링크를 찾을 수 없습니다.");
+
+	private final boolean isSuccess;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/example/luvbackend/exception/pastorbook/PastorBookException.java
+++ b/src/main/java/org/example/luvbackend/exception/pastorbook/PastorBookException.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.exception.pastorbook;
+
+import org.example.luvbackend.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class PastorBookException extends BaseException {
+	private final PastorBookExceptionCode errorCode;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public PastorBookException(PastorBookExceptionCode errorCode) {
+		this.errorCode = errorCode;
+		this.httpStatus = errorCode.getHttpStatus();
+		this.message = errorCode.getMessage();
+	}
+}

--- a/src/main/java/org/example/luvbackend/exception/pastorbook/PastorBookExceptionCode.java
+++ b/src/main/java/org/example/luvbackend/exception/pastorbook/PastorBookExceptionCode.java
@@ -1,0 +1,16 @@
+package org.example.luvbackend.exception.pastorbook;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PastorBookExceptionCode {
+	NOT_FOUND_PASTOR_BOOK(false, HttpStatus.NOT_FOUND, "저서를 찾을 수 없습니다.");
+
+	private final boolean isSuccess;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/example/luvbackend/exception/pastorprofileimage/PastorProfileImageException.java
+++ b/src/main/java/org/example/luvbackend/exception/pastorprofileimage/PastorProfileImageException.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.exception.pastorprofileimage;
+
+import org.example.luvbackend.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class PastorProfileImageException extends BaseException {
+	private final PastorProfileImageExceptionCode errorCode;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public PastorProfileImageException(PastorProfileImageExceptionCode errorCode) {
+		this.errorCode = errorCode;
+		this.httpStatus = errorCode.getHttpStatus();
+		this.message = errorCode.getMessage();
+	}
+}

--- a/src/main/java/org/example/luvbackend/exception/pastorprofileimage/PastorProfileImageExceptionCode.java
+++ b/src/main/java/org/example/luvbackend/exception/pastorprofileimage/PastorProfileImageExceptionCode.java
@@ -1,0 +1,17 @@
+package org.example.luvbackend.exception.pastorprofileimage;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PastorProfileImageExceptionCode {
+	NOT_FOUND_PASTOR_PROFILE_IMAGE(false, HttpStatus.NOT_FOUND, "담임목사 프로필 이미지를 찾을 수 없습니다."),
+	NO_IMAGE_PROVIDED(false, HttpStatus.BAD_REQUEST, "변경할 이미지를 선택해주세요.");
+
+	private final boolean isSuccess;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/example/luvbackend/repository/BibleRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/BibleRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BibleRepository extends MongoRepository<Bible, String> {
-	Page<Bible> findAllByOrderByCreatedAtDesc(Pageable pageable);
+	Page<Bible> findAllByOrderByDateDesc(Pageable pageable);
 
 	default Bible findByIdOrElseThrow(String bibleId) {
 		return findById(bibleId)

--- a/src/main/java/org/example/luvbackend/repository/HomeImageRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/HomeImageRepository.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.repository;
+
+import org.example.luvbackend.entity.homeimage.HomeImage;
+import org.example.luvbackend.exception.homeimage.HomeImageException;
+import org.example.luvbackend.exception.homeimage.HomeImageExceptionCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HomeImageRepository extends MongoRepository<HomeImage, String> {
+	Page<HomeImage> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+	default HomeImage findByIdOrElseThrow(String id) {
+		return findById(id)
+			.orElseThrow(() -> new HomeImageException(HomeImageExceptionCode.NOT_FOUND_HOME_IMAGE));
+	}
+}

--- a/src/main/java/org/example/luvbackend/repository/HomeYoutubeRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/HomeYoutubeRepository.java
@@ -1,0 +1,15 @@
+package org.example.luvbackend.repository;
+
+import org.example.luvbackend.entity.homeyoutube.HomeYoutube;
+import org.example.luvbackend.exception.homeyoutube.HomeYoutubeException;
+import org.example.luvbackend.exception.homeyoutube.HomeYoutubeExceptionCode;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HomeYoutubeRepository extends MongoRepository<HomeYoutube, String> {
+	default HomeYoutube findHomeYoutubeOrElseThrow() {
+		return findById("home_youtube")
+			.orElseThrow(() -> new HomeYoutubeException(HomeYoutubeExceptionCode.NOT_FOUND_HOME_YOUTUBE));
+	}
+}

--- a/src/main/java/org/example/luvbackend/repository/HomeworshipRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/HomeworshipRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HomeworshipRepository extends MongoRepository<HomeWorship, String> {
-	Page<HomeWorship> findAllByOrderByCreatedAtDesc(Pageable pageable);
+	Page<HomeWorship> findAllByOrderByDateDesc(Pageable pageable);
 
 	default HomeWorship findByIdOrElseThrow(String homeworshipId) {
 		return findById(homeworshipId)

--- a/src/main/java/org/example/luvbackend/repository/PastorBookRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/PastorBookRepository.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.repository;
+
+import org.example.luvbackend.entity.pastorbook.PastorBook;
+import org.example.luvbackend.exception.pastorbook.PastorBookException;
+import org.example.luvbackend.exception.pastorbook.PastorBookExceptionCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PastorBookRepository extends MongoRepository<PastorBook, String> {
+	Page<PastorBook> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+	default PastorBook findByIdOrElseThrow(String id) {
+		return findById(id)
+			.orElseThrow(() -> new PastorBookException(PastorBookExceptionCode.NOT_FOUND_PASTOR_BOOK));
+	}
+}

--- a/src/main/java/org/example/luvbackend/repository/PastorProfileImageRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/PastorProfileImageRepository.java
@@ -1,0 +1,15 @@
+package org.example.luvbackend.repository;
+
+import org.example.luvbackend.entity.pastorprofileimage.PastorProfileImage;
+import org.example.luvbackend.exception.pastorprofileimage.PastorProfileImageException;
+import org.example.luvbackend.exception.pastorprofileimage.PastorProfileImageExceptionCode;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PastorProfileImageRepository extends MongoRepository<PastorProfileImage, String> {
+	default PastorProfileImage findProfileImageOrElseThrow() {
+		return findById("pastor-profile-image")
+			.orElseThrow(() -> new PastorProfileImageException(PastorProfileImageExceptionCode.NOT_FOUND_PASTOR_PROFILE_IMAGE));
+	}
+}

--- a/src/main/java/org/example/luvbackend/repository/VideoRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/VideoRepository.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VideoRepository extends MongoRepository<Video, String> {
-	Page<Video> findByTypeOrderByCreatedAtDesc(VideoType type, Pageable pageable);
+	Page<Video> findByTypeOrderByDateDesc(VideoType type, Pageable pageable);
 
-	Page<Video> findAllByOrderByCreatedAtDesc(Pageable pageable);
+	Page<Video> findAllByOrderByDateDesc(Pageable pageable);
 
 	default Video findByIdOrElseThrow(String videoId) {
 		return findById(videoId)

--- a/src/main/java/org/example/luvbackend/service/BibleService.java
+++ b/src/main/java/org/example/luvbackend/service/BibleService.java
@@ -23,7 +23,7 @@ public class BibleService {
 	@Transactional(readOnly = true)
 	public PageResponse<BibleResponseDto> getBibles(int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
-		return PageResponse.of(bibleRepository.findAllByOrderByCreatedAtDesc(pageable)
+		return PageResponse.of(bibleRepository.findAllByOrderByDateDesc(pageable)
 			.map(BibleResponseDto::from));
 	}
 

--- a/src/main/java/org/example/luvbackend/service/HomeImageService.java
+++ b/src/main/java/org/example/luvbackend/service/HomeImageService.java
@@ -1,0 +1,46 @@
+package org.example.luvbackend.service;
+
+import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.dto.aws.S3Directory;
+import org.example.luvbackend.dto.homeimage.HomeImageResponseDto;
+import org.example.luvbackend.entity.homeimage.HomeImage;
+import org.example.luvbackend.exception.homeimage.HomeImageException;
+import org.example.luvbackend.exception.homeimage.HomeImageExceptionCode;
+import org.example.luvbackend.repository.HomeImageRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HomeImageService {
+	private final HomeImageRepository homeImageRepository;
+	private final AwsS3Service awsS3Service;
+
+	@Transactional(readOnly = true)
+	public PageResponse<HomeImageResponseDto> getHomeImages(int page, int size) {
+		return PageResponse.of(
+			homeImageRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(page, size))
+				.map(HomeImageResponseDto::new)
+		);
+	}
+
+	@Transactional
+	public HomeImageResponseDto createHomeImage(MultipartFile image) {
+		if (image == null || image.isEmpty()) {
+			throw new HomeImageException(HomeImageExceptionCode.NO_IMAGE_PROVIDED);
+		}
+		String imageUrl = awsS3Service.uploadFile(image, S3Directory.HOME_IMAGES);
+		return new HomeImageResponseDto(homeImageRepository.save(new HomeImage(imageUrl)));
+	}
+
+	@Transactional
+	public void deleteHomeImage(String id) {
+		HomeImage homeImage = homeImageRepository.findByIdOrElseThrow(id);
+		awsS3Service.deleteFile(homeImage.getImageUrl());
+		homeImageRepository.delete(homeImage);
+	}
+}

--- a/src/main/java/org/example/luvbackend/service/HomeWorshipService.java
+++ b/src/main/java/org/example/luvbackend/service/HomeWorshipService.java
@@ -41,7 +41,7 @@ public class HomeWorshipService {
 	public PageResponse<HomeWorshipResponseDto> getHomeWorships(int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
 		return PageResponse.of(
-			homeworshipRepository.findAllByOrderByCreatedAtDesc(pageable)
+			homeworshipRepository.findAllByOrderByDateDesc(pageable)
 				.map(HomeWorshipResponseDto::from)
 		);
 	}

--- a/src/main/java/org/example/luvbackend/service/HomeYoutubeService.java
+++ b/src/main/java/org/example/luvbackend/service/HomeYoutubeService.java
@@ -1,0 +1,29 @@
+package org.example.luvbackend.service;
+
+import org.example.luvbackend.dto.homeyoutube.HomeYoutubeForm;
+import org.example.luvbackend.dto.homeyoutube.HomeYoutubeResponseDto;
+import org.example.luvbackend.entity.homeyoutube.HomeYoutube;
+import org.example.luvbackend.repository.HomeYoutubeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HomeYoutubeService {
+	private final HomeYoutubeRepository homeYoutubeRepository;
+
+	@Transactional(readOnly = true)
+	public HomeYoutubeResponseDto getHomeYoutube() {
+		return new HomeYoutubeResponseDto(homeYoutubeRepository.findHomeYoutubeOrElseThrow());
+	}
+
+	@Transactional
+	public HomeYoutubeResponseDto updateHomeYoutube(HomeYoutubeForm form) {
+		HomeYoutube homeYoutube = homeYoutubeRepository.findById("home_youtube")
+			.orElse(new HomeYoutube(form.getYoutubeUrl()));
+		homeYoutube.updateYoutubeUrl(form.getYoutubeUrl());
+		return new HomeYoutubeResponseDto(homeYoutubeRepository.save(homeYoutube));
+	}
+}

--- a/src/main/java/org/example/luvbackend/service/PastorBookService.java
+++ b/src/main/java/org/example/luvbackend/service/PastorBookService.java
@@ -54,7 +54,7 @@ public class PastorBookService {
 	// leadership/pastor/pastorBooks/{title}.{ext}
 	private String buildKey(MultipartFile file, String title) {
 		String ext = getExtension(file);
-		return String.format("leadership/pastor/pastorBooks/%s.%s", title, ext);
+		return String.format("leadership/pastor/senior/books/%s.%s", title, ext);
 	}
 
 	private String getExtension(MultipartFile file) {

--- a/src/main/java/org/example/luvbackend/service/PastorBookService.java
+++ b/src/main/java/org/example/luvbackend/service/PastorBookService.java
@@ -1,0 +1,74 @@
+package org.example.luvbackend.service;
+
+import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.dto.pastorbook.PastorBookForm;
+import org.example.luvbackend.dto.pastorbook.PastorBookResponseDto;
+import org.example.luvbackend.entity.pastorbook.PastorBook;
+import org.example.luvbackend.repository.PastorBookRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PastorBookService {
+	private final PastorBookRepository pastorBookRepository;
+	private final AwsS3Service awsS3Service;
+
+	@Transactional(readOnly = true)
+	public PageResponse<PastorBookResponseDto> getPastorBooks(int page, int size) {
+		return PageResponse.of(
+			pastorBookRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(page, size))
+				.map(PastorBookResponseDto::new)
+		);
+	}
+
+	@Transactional
+	public PastorBookResponseDto createPastorBook(PastorBookForm form) {
+		MultipartFile image = form.getImage();
+		if (image == null || image.isEmpty()) {
+			throw new IllegalArgumentException("이미지는 필수입니다.");
+		}
+		String imageUrl = awsS3Service.uploadFile(image, buildKey(image, form.getTitle()));
+		return new PastorBookResponseDto(pastorBookRepository.save(PastorBook.from(form, imageUrl)));
+	}
+
+	@Transactional
+	public PastorBookResponseDto updatePastorBook(String id, PastorBookForm form) {
+		PastorBook pastorBook = pastorBookRepository.findByIdOrElseThrow(id);
+
+		String imageUrl = null;
+		MultipartFile image = form.getImage();
+		if (image != null && !image.isEmpty()) {
+			awsS3Service.deleteFile(pastorBook.getImageUrl());
+			imageUrl = awsS3Service.uploadFile(image, buildKey(image, form.getTitle()));
+		}
+
+		pastorBook.update(form, imageUrl);
+		return new PastorBookResponseDto(pastorBookRepository.save(pastorBook));
+	}
+
+	// leadership/pastor/pastorBooks/{title}.{ext}
+	private String buildKey(MultipartFile file, String title) {
+		String ext = getExtension(file);
+		return String.format("leadership/pastor/pastorBooks/%s.%s", title, ext);
+	}
+
+	private String getExtension(MultipartFile file) {
+		String original = file.getOriginalFilename();
+		if (original != null && original.contains(".")) {
+			return original.substring(original.lastIndexOf('.') + 1).toLowerCase();
+		}
+		return "png";
+	}
+
+	@Transactional
+	public void deletePastorBook(String id) {
+		PastorBook pastorBook = pastorBookRepository.findByIdOrElseThrow(id);
+		awsS3Service.deleteFile(pastorBook.getImageUrl());
+		pastorBookRepository.delete(pastorBook);
+	}
+}

--- a/src/main/java/org/example/luvbackend/service/PastorProfileImageService.java
+++ b/src/main/java/org/example/luvbackend/service/PastorProfileImageService.java
@@ -1,0 +1,59 @@
+package org.example.luvbackend.service;
+
+import org.example.luvbackend.dto.pastorprofileimage.PastorProfileImageForm;
+import org.example.luvbackend.dto.pastorprofileimage.PastorProfileImageResponseDto;
+import org.example.luvbackend.entity.pastorprofileimage.PastorProfileImage;
+import org.example.luvbackend.exception.pastorprofileimage.PastorProfileImageException;
+import org.example.luvbackend.exception.pastorprofileimage.PastorProfileImageExceptionCode;
+import org.example.luvbackend.repository.PastorProfileImageRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PastorProfileImageService {
+	private static final String TOP_KEY = "leadership/pastor/senior/images/top.jpg";
+	private static final String BOTTOM_KEY = "leadership/pastor/senior/images/bottom.jpg";
+
+	private final PastorProfileImageRepository pastorProfileImageRepository;
+	private final AwsS3Service awsS3Service;
+
+	@Transactional(readOnly = true)
+	public PastorProfileImageResponseDto getPastorProfileImage() {
+		return new PastorProfileImageResponseDto(pastorProfileImageRepository.findProfileImageOrElseThrow());
+	}
+
+	@Transactional
+	public PastorProfileImageResponseDto updatePastorProfileImage(PastorProfileImageForm form) {
+		MultipartFile topImage = form.getTopImage();
+		MultipartFile bottomImage = form.getBottomImage();
+
+		boolean hasTop = topImage != null && !topImage.isEmpty();
+		boolean hasBottom = bottomImage != null && !bottomImage.isEmpty();
+
+		if (!hasTop && !hasBottom) {
+			throw new PastorProfileImageException(PastorProfileImageExceptionCode.NO_IMAGE_PROVIDED);
+		}
+
+		PastorProfileImage profile = pastorProfileImageRepository.findById("pastor-profile-image")
+			.orElse(null);
+
+		String topUrl = profile != null ? profile.getTopImageUrl() : null;
+		String bottomUrl = profile != null ? profile.getBottomImageUrl() : null;
+
+		if (hasTop) topUrl = awsS3Service.uploadFile(topImage, TOP_KEY);
+		if (hasBottom) bottomUrl = awsS3Service.uploadFile(bottomImage, BOTTOM_KEY);
+
+		if (profile == null) {
+			profile = new PastorProfileImage(topUrl, bottomUrl);
+		} else {
+			if (hasTop) profile.updateTopImageUrl(topUrl);
+			if (hasBottom) profile.updateBottomImageUrl(bottomUrl);
+		}
+
+		return new PastorProfileImageResponseDto(pastorProfileImageRepository.save(profile));
+	}
+}

--- a/src/main/java/org/example/luvbackend/service/VideoService.java
+++ b/src/main/java/org/example/luvbackend/service/VideoService.java
@@ -29,11 +29,11 @@ public class VideoService {
 		// 타입이 없을 경우
 		if (type == null || type.isBlank()) {
 			Pageable pageable = PageRequest.of(page, size);
-			return PageResponse.of(videoRepository.findAllByOrderByCreatedAtDesc(pageable)
+			return PageResponse.of(videoRepository.findAllByOrderByDateDesc(pageable)
 				.map(VideoResponseDto::from));
 		}
 		VideoType videoType = VideoType.deserialize(type);
-		return PageResponse.of(videoRepository.findByTypeOrderByCreatedAtDesc(videoType, PageRequest.of(page, size))
+		return PageResponse.of(videoRepository.findByTypeOrderByDateDesc(videoType, PageRequest.of(page, size))
 			.map(VideoResponseDto::from)
 		);
 	}


### PR DESCRIPTION
## 변경 사항

- 담임목사님 관련 API 추가 (pastorBooks, pastorProfileImage)
- 사용자페이지 메인 API 추가 (homeContentYoutube, homeContentImages)
- 몇몇 API 조회방법 createdAt -> date로 변경

---

## 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.

---

## 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.

---

## 참고 사항

- 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 페이지 컨텐츠 관리: YouTube 링크 조회 및 업데이트, 이미지 추가 및 삭제 기능 추가
  * 담임목사 저서 관리: 저서 목록 조회, 추가, 수정, 삭제 기능 구현
  * 담임목사 프로필 이미지 관리: 상단/하단 프로필 이미지 조회 및 업데이트 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->