### PR TITLE
Refactor: AWS S3 개발서버 분류 / FileUtils 생성 및 적용

### DIFF
--- a/src/main/java/org/example/luvbackend/common/util/FileUtils.java
+++ b/src/main/java/org/example/luvbackend/common/util/FileUtils.java
@@ -1,0 +1,32 @@
+package org.example.luvbackend.common.util;
+
+/**
+ * S3 key/파일명 생성에 사용하는 문자열 유틸
+ */
+public final class FileUtils {
+
+	private FileUtils() {
+	}
+
+	/**
+	 * 제목 등을 파일명에 안전하게 사용하도록 변환하는 함수
+	 * - 한글/영문/숫자는 유지, 그 외(공백·특수문자·'/')는 '_'로 치환 후 양끝 '_' 제거
+	 */
+	public static String sanitize(String title) {
+		if (title == null) return "";
+		return title.replaceAll("[^\\p{L}\\p{N}]+", "_")
+			.replaceAll("^_+|_+$", "");
+	}
+
+	private static final String DEFAULT_EXTENSION = ".webp";
+
+	/**
+	 * 파일명에서 확장자를 점(.) 포함 + 소문자로 추출
+	 * - 확장자가 없으면 기본값 ".webp" 반환
+	 * ex. "image.JPG" → ".jpg", 확장자 없음 → ".webp"
+	 */
+	public static String extractExtension(String filename) {
+		if (filename == null || !filename.contains(".")) return DEFAULT_EXTENSION;
+		return filename.substring(filename.lastIndexOf('.')).toLowerCase();
+	}
+}

--- a/src/main/java/org/example/luvbackend/controller/education/EducationController.java
+++ b/src/main/java/org/example/luvbackend/controller/education/EducationController.java
@@ -1,0 +1,66 @@
+package org.example.luvbackend.controller.education;
+
+import java.util.List;
+
+import org.example.luvbackend.common.dto.ApiResponse;
+import org.example.luvbackend.dto.education.EducationForm;
+import org.example.luvbackend.dto.education.EducationResponseDto;
+import org.example.luvbackend.service.EducationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/education")
+@RequiredArgsConstructor
+public class EducationController {
+	private final EducationService educationService;
+
+	@Operation(summary = "다음세대 부서 목록 조회")
+	@GetMapping
+	public ApiResponse<List<EducationResponseDto>> getEducations() {
+		return ApiResponse.success(educationService.getEducations());
+	}
+
+	@Operation(summary = "다음세대 부서 단건 조회 (type)")
+	@GetMapping("/{type}")
+	public ApiResponse<EducationResponseDto> getEducationByType(@PathVariable(name = "type") String type) {
+		return ApiResponse.success(educationService.getEducationByType(type));
+	}
+
+	@Operation(summary = "다음세대 부서 등록")
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<EducationResponseDto> createEducation(@ModelAttribute @Valid EducationForm form) {
+		return ApiResponse.created(educationService.createEducation(form));
+	}
+
+	@Operation(summary = "다음세대 부서 수정")
+	@PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ApiResponse<EducationResponseDto> updateEducation(
+		@PathVariable(name = "id") String id,
+		@ModelAttribute @Valid EducationForm form
+	) {
+		return ApiResponse.success(educationService.updateEducation(id, form));
+	}
+
+	@Operation(summary = "다음세대 부서 삭제")
+	@DeleteMapping("/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public ApiResponse<Void> deleteEducation(@PathVariable(name = "id") String id) {
+		educationService.deleteEducation(id);
+		return ApiResponse.noContent();
+	}
+}

--- a/src/main/java/org/example/luvbackend/controller/education/EducationHomeController.java
+++ b/src/main/java/org/example/luvbackend/controller/education/EducationHomeController.java
@@ -1,0 +1,34 @@
+package org.example.luvbackend.controller.education;
+
+import org.example.luvbackend.common.dto.ApiResponse;
+import org.example.luvbackend.dto.education.EducationHomeForm;
+import org.example.luvbackend.dto.education.EducationHomeResponseDto;
+import org.example.luvbackend.service.EducationHomeService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/education-home")
+@RequiredArgsConstructor
+public class EducationHomeController {
+	private final EducationHomeService educationHomeService;
+
+	@Operation(summary = "다음세대 홈 콘텐츠 조회")
+	@GetMapping
+	public ApiResponse<EducationHomeResponseDto> get() {
+		return ApiResponse.success(educationHomeService.get());
+	}
+
+	@Operation(summary = "다음세대 홈 콘텐츠 저장/업데이트")
+	@PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ApiResponse<EducationHomeResponseDto> upsert(@ModelAttribute EducationHomeForm form) {
+		return ApiResponse.success(educationHomeService.upsert(form));
+	}
+}

--- a/src/main/java/org/example/luvbackend/dto/aws/S3Directory.java
+++ b/src/main/java/org/example/luvbackend/dto/aws/S3Directory.java
@@ -13,7 +13,8 @@ public enum S3Directory {
 	MISSION_NEWS("missionNewsList"),
 	POPUPS("popups"),
 	LEADERSHIP("leadership"),
-	HOME_IMAGES("homeContent/images");
+	HOME_IMAGES("homeContent/images"),
+	EDUCATION("education");
 
 	private final String path;
 }

--- a/src/main/java/org/example/luvbackend/dto/education/CoreMinistryInput.java
+++ b/src/main/java/org/example/luvbackend/dto/education/CoreMinistryInput.java
@@ -1,0 +1,17 @@
+package org.example.luvbackend.dto.education;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CoreMinistryInput {
+	private String titleKr;
+	private String titleEn;
+	private String description;
+	private String imgClass;
+	/** 기존 이미지 URL 유지할 때 사용 (이미지 새로 업로드 안 한 경우) */
+	private String imageUrl;
+}

--- a/src/main/java/org/example/luvbackend/dto/education/EducationForm.java
+++ b/src/main/java/org/example/luvbackend/dto/education/EducationForm.java
@@ -1,0 +1,46 @@
+package org.example.luvbackend.dto.education;
+
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EducationForm {
+	@NotBlank
+	private String type;
+
+	private String slug;
+	private String department;
+	private String heroImgClass;
+	private String introduction;
+	private String target;
+	private String time;
+	private String place;
+	private String meetingTime;
+	private String order;
+
+	/** 배너 이미지 */
+	private MultipartFile heroImage;
+
+	/** 상단 이미지들 (기존 유지할 URL 목록) */
+	private List<String> existingImageUrls;
+
+	/** 새로 업로드할 상단 이미지들 */
+	private List<MultipartFile> images;
+
+	/** 핵심 사역 메타데이터 (JSON 문자열) — 형식: CoreMinistryInput 배열 */
+	private String coreMinistriesJson;
+
+	/** 핵심 사역 이미지들 — 인덱스 순서대로 코어 사역에 매핑 (없으면 imageUrl 유지) */
+	private List<MultipartFile> coreMinistryImages;
+
+	/** coreMinistryImages 와 1:1 매핑되는 인덱스. ex: [0, 2] → 0번/2번 코어사역의 이미지 교체 */
+	private List<Integer> coreMinistryImageIndexes;
+}

--- a/src/main/java/org/example/luvbackend/dto/education/EducationHomeForm.java
+++ b/src/main/java/org/example/luvbackend/dto/education/EducationHomeForm.java
@@ -1,0 +1,22 @@
+package org.example.luvbackend.dto.education;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EducationHomeForm {
+	private String heroImgClass;
+	private String heroSubtitle;
+	private String missionLine1;
+	private String missionLine2;
+	/** JSON 문자열: [{lead, emphasis, bold}] */
+	private String visionsJson;
+	/** JSON 문자열: [{n, title}] */
+	private String coreValuesJson;
+	private MultipartFile heroImage;
+}

--- a/src/main/java/org/example/luvbackend/dto/education/EducationHomeResponseDto.java
+++ b/src/main/java/org/example/luvbackend/dto/education/EducationHomeResponseDto.java
@@ -1,0 +1,68 @@
+package org.example.luvbackend.dto.education;
+
+import java.util.List;
+
+import org.example.luvbackend.entity.education.EducationHome;
+import org.example.luvbackend.entity.education.EducationHomeCoreValue;
+import org.example.luvbackend.entity.education.EducationHomeVision;
+
+import lombok.Getter;
+
+@Getter
+public class EducationHomeResponseDto {
+	private final String id;
+	private final String heroImageUrl;
+	private final String heroImgClass;
+	private final String heroSubtitle;
+	private final String missionLine1;
+	private final String missionLine2;
+	private final List<VisionDto> visions;
+	private final List<CoreValueDto> coreValues;
+
+	private EducationHomeResponseDto(EducationHome home) {
+		this.id = home.getId();
+		this.heroImageUrl = home.getHeroImageUrl();
+		this.heroImgClass = home.getHeroImgClass();
+		this.heroSubtitle = home.getHeroSubtitle();
+		this.missionLine1 = home.getMissionLine1();
+		this.missionLine2 = home.getMissionLine2();
+		this.visions = home.getVisions().stream().map(VisionDto::from).toList();
+		this.coreValues = home.getCoreValues().stream().map(CoreValueDto::from).toList();
+	}
+
+	public static EducationHomeResponseDto from(EducationHome home) {
+		return new EducationHomeResponseDto(home);
+	}
+
+	@Getter
+	public static class VisionDto {
+		private final String lead;
+		private final String emphasis;
+		private final String bold;
+
+		private VisionDto(EducationHomeVision v) {
+			this.lead = v.getLead();
+			this.emphasis = v.getEmphasis();
+			this.bold = v.getBold();
+		}
+
+		public static VisionDto from(EducationHomeVision v) {
+			return new VisionDto(v);
+		}
+	}
+
+	@Getter
+	public static class CoreValueDto {
+		private final String n;
+		private final String title;
+
+		private CoreValueDto(EducationHomeCoreValue c) {
+			this.n = c.getN();
+			this.title = c.getTitle();
+		}
+
+		public static CoreValueDto from(EducationHomeCoreValue c) {
+			return new CoreValueDto(c);
+		}
+	}
+}

--- a/src/main/java/org/example/luvbackend/dto/education/EducationResponseDto.java
+++ b/src/main/java/org/example/luvbackend/dto/education/EducationResponseDto.java
@@ -1,0 +1,72 @@
+package org.example.luvbackend.dto.education;
+
+import java.util.List;
+
+import org.example.luvbackend.entity.education.CoreMinistry;
+import org.example.luvbackend.entity.education.Education;
+
+import lombok.Getter;
+
+@Getter
+public class EducationResponseDto {
+	private final String id;
+	private final String type;
+	private final String slug;
+	private final String department;
+	private final String heroImageUrl;
+	private final String heroImgClass;
+	private final List<String> imageUrls;
+	private final String introduction;
+	private final String target;
+	private final String time;
+	private final String place;
+	private final String meetingTime;
+	private final List<CoreMinistryDto> coreMinistries;
+	private final Integer order;
+	private final Long createdAt;
+
+	private EducationResponseDto(Education e) {
+		this.id = e.getId();
+		this.type = e.getType();
+		this.slug = e.getSlug();
+		this.department = e.getDepartment();
+		this.heroImageUrl = e.getHeroImageUrl();
+		this.heroImgClass = e.getHeroImgClass();
+		this.imageUrls = e.getImageUrls();
+		this.introduction = e.getIntroduction();
+		this.target = e.getTarget();
+		this.time = e.getTime();
+		this.place = e.getPlace();
+		this.meetingTime = e.getMeetingTime();
+		this.coreMinistries = e.getCoreMinistries().stream()
+			.map(CoreMinistryDto::from)
+			.toList();
+		this.order = e.getOrder();
+		this.createdAt = e.getCreatedAt();
+	}
+
+	public static EducationResponseDto from(Education education) {
+		return new EducationResponseDto(education);
+	}
+
+	@Getter
+	public static class CoreMinistryDto {
+		private final String titleKr;
+		private final String titleEn;
+		private final String description;
+		private final String imageUrl;
+		private final String imgClass;
+
+		private CoreMinistryDto(CoreMinistry c) {
+			this.titleKr = c.getTitleKr();
+			this.titleEn = c.getTitleEn();
+			this.description = c.getDescription();
+			this.imageUrl = c.getImageUrl();
+			this.imgClass = c.getImgClass();
+		}
+
+		public static CoreMinistryDto from(CoreMinistry c) {
+			return new CoreMinistryDto(c);
+		}
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/education/CoreMinistry.java
+++ b/src/main/java/org/example/luvbackend/entity/education/CoreMinistry.java
@@ -1,0 +1,25 @@
+package org.example.luvbackend.entity.education;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoreMinistry {
+	private String titleKr;
+	private String titleEn;
+	private String description;
+	private String imageUrl;
+	private String imgClass;
+
+	@Builder
+	public CoreMinistry(String titleKr, String titleEn, String description, String imageUrl, String imgClass) {
+		this.titleKr = titleKr;
+		this.titleEn = titleEn;
+		this.description = description;
+		this.imageUrl = imageUrl;
+		this.imgClass = imgClass;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/education/Education.java
+++ b/src/main/java/org/example/luvbackend/entity/education/Education.java
@@ -1,0 +1,74 @@
+package org.example.luvbackend.entity.education;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.example.luvbackend.common.entity.BaseEntity;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "education")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Education extends BaseEntity {
+	@Id
+	private String id;
+
+	@Indexed(unique = true)
+	private String type; // infants, toddlers, elementary, high, 2youth, bridge
+
+	private String slug;
+	private String department;
+	private String heroImageUrl;
+	private String heroImgClass;
+	private List<String> imageUrls = new ArrayList<>();
+	private String introduction;
+	private String target;
+	private String time;
+	private String place;
+	private String meetingTime;
+	private List<CoreMinistry> coreMinistries = new ArrayList<>();
+	private Integer order;
+
+	@Builder
+	private Education(String type, String slug, String department, String heroImageUrl, String heroImgClass,
+		List<String> imageUrls, String introduction, String target, String time, String place,
+		String meetingTime, List<CoreMinistry> coreMinistries, Integer order) {
+		this.type = type;
+		this.slug = slug;
+		this.department = department;
+		this.heroImageUrl = heroImageUrl;
+		this.heroImgClass = heroImgClass;
+		this.imageUrls = imageUrls != null ? imageUrls : new ArrayList<>();
+		this.introduction = introduction;
+		this.target = target;
+		this.time = time;
+		this.place = place;
+		this.meetingTime = meetingTime;
+		this.coreMinistries = coreMinistries != null ? coreMinistries : new ArrayList<>();
+		this.order = order;
+	}
+
+	public void update(String slug, String department, String heroImageUrl, String heroImgClass,
+		List<String> imageUrls, String introduction, String target, String time, String place,
+		String meetingTime, List<CoreMinistry> coreMinistries, Integer order) {
+		if (slug != null) this.slug = slug;
+		if (department != null) this.department = department;
+		if (heroImageUrl != null) this.heroImageUrl = heroImageUrl;
+		if (heroImgClass != null) this.heroImgClass = heroImgClass;
+		if (imageUrls != null) this.imageUrls = imageUrls;
+		if (introduction != null) this.introduction = introduction;
+		if (target != null) this.target = target;
+		if (time != null) this.time = time;
+		if (place != null) this.place = place;
+		if (meetingTime != null) this.meetingTime = meetingTime;
+		if (coreMinistries != null) this.coreMinistries = coreMinistries;
+		if (order != null) this.order = order;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/education/EducationHome.java
+++ b/src/main/java/org/example/luvbackend/entity/education/EducationHome.java
@@ -1,0 +1,54 @@
+package org.example.luvbackend.entity.education;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.example.luvbackend.common.entity.BaseEntity;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "education_home")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EducationHome extends BaseEntity {
+	@Id
+	private String id;
+
+	private String heroImageUrl;
+	private String heroImgClass;
+	private String heroSubtitle; // 예: "일어나라 빛을 발하라!"
+	private String missionLine1; // 예: "명문교회 교육부서는"
+	private String missionLine2; // 예: "하나님을 경외하는 다음세대를 세우기 위해 존재한다."
+	private List<EducationHomeVision> visions = new ArrayList<>();
+	private List<EducationHomeCoreValue> coreValues = new ArrayList<>();
+
+	@Builder
+	private EducationHome(String heroImageUrl, String heroImgClass, String heroSubtitle,
+		String missionLine1, String missionLine2,
+		List<EducationHomeVision> visions, List<EducationHomeCoreValue> coreValues) {
+		this.heroImageUrl = heroImageUrl;
+		this.heroImgClass = heroImgClass;
+		this.heroSubtitle = heroSubtitle;
+		this.missionLine1 = missionLine1;
+		this.missionLine2 = missionLine2;
+		this.visions = visions != null ? visions : new ArrayList<>();
+		this.coreValues = coreValues != null ? coreValues : new ArrayList<>();
+	}
+
+	public void update(String heroImageUrl, String heroImgClass, String heroSubtitle,
+		String missionLine1, String missionLine2,
+		List<EducationHomeVision> visions, List<EducationHomeCoreValue> coreValues) {
+		if (heroImageUrl != null) this.heroImageUrl = heroImageUrl;
+		if (heroImgClass != null) this.heroImgClass = heroImgClass;
+		if (heroSubtitle != null) this.heroSubtitle = heroSubtitle;
+		if (missionLine1 != null) this.missionLine1 = missionLine1;
+		if (missionLine2 != null) this.missionLine2 = missionLine2;
+		if (visions != null) this.visions = visions;
+		if (coreValues != null) this.coreValues = coreValues;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/education/EducationHomeCoreValue.java
+++ b/src/main/java/org/example/luvbackend/entity/education/EducationHomeCoreValue.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.entity.education;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EducationHomeCoreValue {
+	private String n;
+	private String title;
+
+	@Builder
+	public EducationHomeCoreValue(String n, String title) {
+		this.n = n;
+		this.title = title;
+	}
+}

--- a/src/main/java/org/example/luvbackend/entity/education/EducationHomeVision.java
+++ b/src/main/java/org/example/luvbackend/entity/education/EducationHomeVision.java
@@ -1,0 +1,21 @@
+package org.example.luvbackend.entity.education;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EducationHomeVision {
+	private String lead;
+	private String emphasis;
+	private String bold;
+
+	@Builder
+	public EducationHomeVision(String lead, String emphasis, String bold) {
+		this.lead = lead;
+		this.emphasis = emphasis;
+		this.bold = bold;
+	}
+}

--- a/src/main/java/org/example/luvbackend/exception/education/EducationException.java
+++ b/src/main/java/org/example/luvbackend/exception/education/EducationException.java
@@ -1,0 +1,19 @@
+package org.example.luvbackend.exception.education;
+
+import org.example.luvbackend.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class EducationException extends BaseException {
+	private final EducationExceptionCode errorCode;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public EducationException(EducationExceptionCode errorCode) {
+		this.errorCode = errorCode;
+		this.httpStatus = errorCode.getHttpStatus();
+		this.message = errorCode.getMessage();
+	}
+}

--- a/src/main/java/org/example/luvbackend/exception/education/EducationExceptionCode.java
+++ b/src/main/java/org/example/luvbackend/exception/education/EducationExceptionCode.java
@@ -1,0 +1,18 @@
+package org.example.luvbackend.exception.education;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EducationExceptionCode {
+	NOT_FOUND_EDUCATION(false, HttpStatus.NOT_FOUND, "다음세대 부서를 찾을 수 없습니다."),
+	DUPLICATE_TYPE(false, HttpStatus.CONFLICT, "이미 등록된 부서 타입입니다."),
+	INVALID_CORE_MINISTRIES(false, HttpStatus.BAD_REQUEST, "핵심 사역 데이터 형식이 올바르지 않습니다.");
+
+	private final boolean isSuccess;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/org/example/luvbackend/repository/EducationHomeRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/EducationHomeRepository.java
@@ -1,0 +1,9 @@
+package org.example.luvbackend.repository;
+
+import org.example.luvbackend.entity.education.EducationHome;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EducationHomeRepository extends MongoRepository<EducationHome, String> {
+}

--- a/src/main/java/org/example/luvbackend/repository/EducationRepository.java
+++ b/src/main/java/org/example/luvbackend/repository/EducationRepository.java
@@ -1,0 +1,24 @@
+package org.example.luvbackend.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.example.luvbackend.entity.education.Education;
+import org.example.luvbackend.exception.education.EducationException;
+import org.example.luvbackend.exception.education.EducationExceptionCode;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EducationRepository extends MongoRepository<Education, String> {
+	List<Education> findAllByOrderByOrderAsc();
+
+	Optional<Education> findByType(String type);
+
+	boolean existsByType(String type);
+
+	default Education findByIdOrElseThrow(String id) {
+		return findById(id)
+			.orElseThrow(() -> new EducationException(EducationExceptionCode.NOT_FOUND_EDUCATION));
+	}
+}

--- a/src/main/java/org/example/luvbackend/service/AlbumService.java
+++ b/src/main/java/org/example/luvbackend/service/AlbumService.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.common.util.FileUtils;
 import org.example.luvbackend.dto.album.AlbumResponseDto;
 import org.example.luvbackend.dto.album.AlbumUpdateForm;
 import org.example.luvbackend.dto.album.AlbumUploadForm;
@@ -126,16 +127,9 @@ public class AlbumService {
 		List<String> keys = new ArrayList<>();
 		int index = startIndex;
 		for (MultipartFile file : files) {
-			keys.add(String.format("albums/%s/%s/%s/%02d.%s", type, date, uuid, index++, getExtension(file)));
+			keys.add(String.format("albums/%s/%s/%s/%02d%s", type, date, uuid, index++,
+				FileUtils.extractExtension(file.getOriginalFilename())));
 		}
 		return keys;
-	}
-
-	private String getExtension(MultipartFile file) {
-		String original = file.getOriginalFilename();
-		if (original != null && original.contains(".")) {
-			return original.substring(original.lastIndexOf('.') + 1).toLowerCase();
-		}
-		return "jpg";
 	}
 }

--- a/src/main/java/org/example/luvbackend/service/AwsS3Service.java
+++ b/src/main/java/org/example/luvbackend/service/AwsS3Service.java
@@ -26,10 +26,25 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 @Service
 @RequiredArgsConstructor
 public class AwsS3Service {
+	// 모든 업로드 key가 고유(UUID/타임스탬프)하므로 1년 캐싱 + 재검증 생략
+	private static final String CACHE_CONTROL = "public, max-age=31536000, immutable";
+
 	private final S3Client awsS3Client;
 
 	@Value("${spring.cloud.aws.s3.bucket}")
 	private String bucket;
+
+	@Value("${spring.cloud.aws.s3.prefix:}")
+	private String prefix; // 버킷 내 최상위 폴더 (local: dev, prod: 없음)
+
+	/**
+	 * prefix가 설정된 환경(local)에서만 key 앞에 prefix를 붙이는 메서드
+	 * ex. (prefix=dev) albums/xxx.jpg → dev/albums/xxx.jpg
+	 */
+	private String withPrefix(String key) {
+		if (prefix == null || prefix.isBlank()) return key;
+		return prefix + "/" + key;
+	}
 
 	/**
 	 * 다건 파일 업로드 후 URL 리스트 반환 메서드
@@ -61,7 +76,8 @@ public class AwsS3Service {
 	/**
 	 * 단건 파일 업로드 - key를 직접 지정
 	 */
-	public String uploadFile(MultipartFile file, String key) {
+	public String uploadFile(MultipartFile file, String inputKey) {
+		String key = withPrefix(inputKey);
 		try {
 			awsS3Client.putObject(
 				PutObjectRequest.builder()
@@ -69,6 +85,7 @@ public class AwsS3Service {
 					.key(key)
 					.contentType(file.getContentType())
 					.contentLength(file.getSize())
+					.cacheControl(CACHE_CONTROL)
 					.build(),
 				RequestBody.fromInputStream(file.getInputStream(), file.getSize())
 			);
@@ -85,7 +102,7 @@ public class AwsS3Service {
 		String dirName = s3Directory.getPath(); // ex. albums, bulletins, videos
 		String fileName = file.getOriginalFilename(); // ex. image.jpg
 		UUID uuid = UUID.randomUUID(); // ex. 1234567890
-		String key = dirName + "/" + uuid + "_" + fileName; // ex. albums/1234567890_image.jpg
+		String key = withPrefix(dirName + "/" + uuid + "_" + fileName); // ex. dev/albums/1234567890_image.jpg
 
 		try {
 			// S3 업로드
@@ -95,6 +112,7 @@ public class AwsS3Service {
 					.key(key)
 					.contentType(file.getContentType())
 					.contentLength(file.getSize())
+					.cacheControl(CACHE_CONTROL)
 					.build(),
 				RequestBody.fromInputStream(file.getInputStream(), file.getSize())
 			);
@@ -111,13 +129,15 @@ public class AwsS3Service {
 	/**
 	 * byte 배열을 지정된 key로 S3에 업로드 후 URL 반환
 	 */
-	public String uploadBytes(byte[] bytes, String key, String contentType) {
+	public String uploadBytes(byte[] bytes, String inputKey, String contentType) {
+		String key = withPrefix(inputKey);
 		awsS3Client.putObject(
 			PutObjectRequest.builder()
 				.bucket(bucket)
 				.key(key)
 				.contentType(contentType)
 				.contentLength((long) bytes.length)
+				.cacheControl(CACHE_CONTROL)
 				.build(),
 			RequestBody.fromBytes(bytes)
 		);

--- a/src/main/java/org/example/luvbackend/service/EducationHomeService.java
+++ b/src/main/java/org/example/luvbackend/service/EducationHomeService.java
@@ -1,0 +1,123 @@
+package org.example.luvbackend.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.example.luvbackend.common.util.FileUtils;
+import org.example.luvbackend.dto.education.EducationHomeForm;
+import org.example.luvbackend.dto.education.EducationHomeResponseDto;
+import org.example.luvbackend.entity.education.EducationHome;
+import org.example.luvbackend.entity.education.EducationHomeCoreValue;
+import org.example.luvbackend.entity.education.EducationHomeVision;
+import org.example.luvbackend.exception.education.EducationException;
+import org.example.luvbackend.exception.education.EducationExceptionCode;
+import org.example.luvbackend.repository.EducationHomeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EducationHomeService {
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+	private final EducationHomeRepository repository;
+	private final AwsS3Service awsS3Service;
+	private final ObjectMapper objectMapper;
+
+	@Transactional(readOnly = true)
+	public EducationHomeResponseDto get() {
+		EducationHome home = repository.findAll().stream().findFirst().orElse(null);
+		if (home == null) return null;
+		return EducationHomeResponseDto.from(home);
+	}
+
+	@Transactional
+	public EducationHomeResponseDto upsert(EducationHomeForm form) {
+		EducationHome existing = repository.findAll().stream().findFirst().orElse(null);
+
+		List<EducationHomeVision> visions = parseVisions(form.getVisionsJson());
+		List<EducationHomeCoreValue> coreValues = parseCoreValues(form.getCoreValuesJson());
+
+		String heroImageUrl = null;
+		MultipartFile heroImage = form.getHeroImage();
+		if (heroImage != null && !heroImage.isEmpty()) {
+			if (existing != null && existing.getHeroImageUrl() != null) {
+				awsS3Service.deleteFiles(List.of(existing.getHeroImageUrl()));
+			}
+			heroImageUrl = awsS3Service.uploadFile(heroImage, buildKey(heroImage));
+		}
+
+		if (existing == null) {
+			EducationHome home = EducationHome.builder()
+				.heroImageUrl(heroImageUrl)
+				.heroImgClass(form.getHeroImgClass())
+				.heroSubtitle(form.getHeroSubtitle())
+				.missionLine1(form.getMissionLine1())
+				.missionLine2(form.getMissionLine2())
+				.visions(visions)
+				.coreValues(coreValues)
+				.build();
+			return EducationHomeResponseDto.from(repository.save(home));
+		}
+
+		existing.update(
+			heroImageUrl,
+			form.getHeroImgClass(),
+			form.getHeroSubtitle(),
+			form.getMissionLine1(),
+			form.getMissionLine2(),
+			visions,
+			coreValues
+		);
+		return EducationHomeResponseDto.from(repository.save(existing));
+	}
+
+	private List<EducationHomeVision> parseVisions(String json) {
+		if (json == null || json.isBlank()) return null;
+		try {
+			List<VisionInput> inputs = objectMapper.readValue(json, new TypeReference<>() {});
+			return inputs.stream()
+				.map(i -> EducationHomeVision.builder()
+					.lead(i.lead).emphasis(i.emphasis).bold(i.bold).build())
+				.toList();
+		} catch (Exception e) {
+			throw new EducationException(EducationExceptionCode.INVALID_CORE_MINISTRIES);
+		}
+	}
+
+	private List<EducationHomeCoreValue> parseCoreValues(String json) {
+		if (json == null || json.isBlank()) return null;
+		try {
+			List<CoreValueInput> inputs = objectMapper.readValue(json, new TypeReference<>() {});
+			return inputs.stream()
+				.map(i -> EducationHomeCoreValue.builder().n(i.n).title(i.title).build())
+				.toList();
+		} catch (Exception e) {
+			throw new EducationException(EducationExceptionCode.INVALID_CORE_MINISTRIES);
+		}
+	}
+
+	private String buildKey(MultipartFile file) {
+		String now = LocalDateTime.now().format(FORMATTER);
+		String ext = FileUtils.extractExtension(file.getOriginalFilename());
+		return "education/home/hero_" + now + ext;
+	}
+
+	private static class VisionInput {
+		public String lead;
+		public String emphasis;
+		public String bold;
+	}
+
+	private static class CoreValueInput {
+		public String n;
+		public String title;
+	}
+}

--- a/src/main/java/org/example/luvbackend/service/EducationService.java
+++ b/src/main/java/org/example/luvbackend/service/EducationService.java
@@ -1,0 +1,267 @@
+package org.example.luvbackend.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.example.luvbackend.common.util.FileUtils;
+import org.example.luvbackend.dto.education.CoreMinistryInput;
+import org.example.luvbackend.dto.education.EducationForm;
+import org.example.luvbackend.dto.education.EducationResponseDto;
+import org.example.luvbackend.entity.education.CoreMinistry;
+import org.example.luvbackend.entity.education.Education;
+import org.example.luvbackend.exception.education.EducationException;
+import org.example.luvbackend.exception.education.EducationExceptionCode;
+import org.example.luvbackend.repository.EducationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EducationService {
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+	private final EducationRepository educationRepository;
+	private final AwsS3Service awsS3Service;
+	private final ObjectMapper objectMapper;
+
+	@Transactional(readOnly = true)
+	public List<EducationResponseDto> getEducations() {
+		return educationRepository.findAll().stream()
+			.sorted(Comparator.comparing(
+				Education::getOrder,
+				Comparator.nullsLast(Comparator.naturalOrder())
+			))
+			.map(EducationResponseDto::from)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public EducationResponseDto getEducationByType(String type) {
+		return educationRepository.findByType(type)
+			.map(EducationResponseDto::from)
+			.orElseThrow(() -> new EducationException(EducationExceptionCode.NOT_FOUND_EDUCATION));
+	}
+
+	@Transactional
+	public EducationResponseDto createEducation(EducationForm form) {
+		if (educationRepository.existsByType(form.getType())) {
+			throw new EducationException(EducationExceptionCode.DUPLICATE_TYPE);
+		}
+
+		String heroImageUrl = form.getHeroImage() != null && !form.getHeroImage().isEmpty()
+			? awsS3Service.uploadFile(form.getHeroImage(), buildKey(form.getType(), "hero", form.getHeroImage()))
+			: null;
+
+		List<String> imageUrls = uploadImages(form.getType(), "imgs", form.getImages());
+		List<CoreMinistry> coreMinistries = buildCoreMinistries(form);
+
+		Education education = Education.builder()
+			.type(form.getType())
+			.slug(form.getSlug())
+			.department(form.getDepartment())
+			.heroImageUrl(heroImageUrl)
+			.heroImgClass(form.getHeroImgClass())
+			.imageUrls(imageUrls)
+			.introduction(form.getIntroduction())
+			.target(form.getTarget())
+			.time(form.getTime())
+			.place(form.getPlace())
+			.meetingTime(form.getMeetingTime())
+			.coreMinistries(coreMinistries)
+			.order(parseOrder(form.getOrder()))
+			.build();
+
+		return EducationResponseDto.from(educationRepository.save(education));
+	}
+
+	@Transactional
+	public EducationResponseDto updateEducation(String id, EducationForm form) {
+		Education education = educationRepository.findByIdOrElseThrow(id);
+
+		// 배너 이미지 교체
+		String heroImageUrl = null;
+		MultipartFile heroImage = form.getHeroImage();
+		if (heroImage != null && !heroImage.isEmpty()) {
+			if (education.getHeroImageUrl() != null) {
+				awsS3Service.deleteFiles(List.of(education.getHeroImageUrl()));
+			}
+			heroImageUrl = awsS3Service.uploadFile(heroImage, buildKey(education.getType(), "hero", heroImage));
+		}
+
+		// 상단 이미지 교체 (기존 유지 + 새로 추가)
+		List<String> finalImageUrls = mergeImageUrls(
+			education.getImageUrls(),
+			form.getExistingImageUrls(),
+			form.getImages(),
+			education.getType()
+		);
+
+		// 핵심사역 처리
+		List<CoreMinistry> coreMinistries = buildUpdatedCoreMinistries(education, form);
+
+		education.update(
+			form.getSlug(),
+			form.getDepartment(),
+			heroImageUrl,
+			form.getHeroImgClass(),
+			finalImageUrls,
+			form.getIntroduction(),
+			form.getTarget(),
+			form.getTime(),
+			form.getPlace(),
+			form.getMeetingTime(),
+			coreMinistries,
+			parseOrder(form.getOrder())
+		);
+
+		return EducationResponseDto.from(educationRepository.save(education));
+	}
+
+	@Transactional
+	public void deleteEducation(String id) {
+		Education education = educationRepository.findByIdOrElseThrow(id);
+		List<String> urls = new ArrayList<>();
+		if (education.getHeroImageUrl() != null) urls.add(education.getHeroImageUrl());
+		urls.addAll(education.getImageUrls());
+		education.getCoreMinistries().forEach(c -> {
+			if (c.getImageUrl() != null) urls.add(c.getImageUrl());
+		});
+		if (!urls.isEmpty()) awsS3Service.deleteFiles(urls);
+		educationRepository.delete(education);
+	}
+
+	private List<String> uploadImages(String type, String prefix, List<MultipartFile> files) {
+		if (files == null || files.isEmpty()) return new ArrayList<>();
+		List<String> urls = new ArrayList<>();
+		for (MultipartFile file : files) {
+			if (file == null || file.isEmpty()) continue;
+			urls.add(awsS3Service.uploadFile(file, buildKey(type, prefix, file)));
+		}
+		return urls;
+	}
+
+	private List<String> mergeImageUrls(List<String> existingInDb, List<String> existingFromForm,
+		List<MultipartFile> newFiles, String type) {
+		List<String> result = new ArrayList<>();
+
+		// 폼에서 유지하라고 보낸 URL만 남김
+		if (existingFromForm != null && !existingFromForm.isEmpty()) {
+			result.addAll(existingFromForm);
+			// 유지 안 되는 기존 이미지는 S3에서 삭제
+			List<String> toDelete = existingInDb.stream()
+				.filter(url -> !existingFromForm.contains(url))
+				.toList();
+			if (!toDelete.isEmpty()) awsS3Service.deleteFiles(toDelete);
+		} else if (existingFromForm == null) {
+			// 전달 안 했으면 기존 유지
+			result.addAll(existingInDb);
+		} else {
+			// 빈 배열로 보내면 전부 삭제
+			if (!existingInDb.isEmpty()) awsS3Service.deleteFiles(existingInDb);
+		}
+
+		// 새 이미지 추가
+		result.addAll(uploadImages(type, "imgs", newFiles));
+		return result;
+	}
+
+	private List<CoreMinistry> buildCoreMinistries(EducationForm form) {
+		List<CoreMinistryInput> inputs = parseCoreMinistries(form.getCoreMinistriesJson());
+		List<CoreMinistry> result = new ArrayList<>();
+		for (int i = 0; i < inputs.size(); i++) {
+			CoreMinistryInput input = inputs.get(i);
+			String imageUrl = uploadCoreMinistryImage(form, i, input.getImageUrl());
+			result.add(CoreMinistry.builder()
+				.titleKr(input.getTitleKr())
+				.titleEn(input.getTitleEn())
+				.description(input.getDescription())
+				.imageUrl(imageUrl)
+				.imgClass(input.getImgClass())
+				.build());
+		}
+		return result;
+	}
+
+	private List<CoreMinistry> buildUpdatedCoreMinistries(Education education, EducationForm form) {
+		// JSON 없으면 기존 유지
+		if (form.getCoreMinistriesJson() == null || form.getCoreMinistriesJson().isBlank()) {
+			return education.getCoreMinistries();
+		}
+
+		List<CoreMinistryInput> inputs = parseCoreMinistries(form.getCoreMinistriesJson());
+		List<CoreMinistry> result = new ArrayList<>();
+		List<String> oldUrls = education.getCoreMinistries().stream()
+			.map(CoreMinistry::getImageUrl)
+			.filter(url -> url != null)
+			.toList();
+		List<String> keptUrls = new ArrayList<>();
+
+		for (int i = 0; i < inputs.size(); i++) {
+			CoreMinistryInput input = inputs.get(i);
+			String imageUrl = uploadCoreMinistryImage(form, i, input.getImageUrl());
+			if (imageUrl != null) keptUrls.add(imageUrl);
+			result.add(CoreMinistry.builder()
+				.titleKr(input.getTitleKr())
+				.titleEn(input.getTitleEn())
+				.description(input.getDescription())
+				.imageUrl(imageUrl)
+				.imgClass(input.getImgClass())
+				.build());
+		}
+
+		// 더 이상 사용되지 않는 기존 이미지 삭제
+		List<String> toDelete = oldUrls.stream().filter(url -> !keptUrls.contains(url)).toList();
+		if (!toDelete.isEmpty()) awsS3Service.deleteFiles(toDelete);
+		return result;
+	}
+
+	/** 인덱스 i에 해당하는 핵심사역 이미지를 업로드, 없으면 입력의 기존 imageUrl 그대로 반환 */
+	private String uploadCoreMinistryImage(EducationForm form, int index, String existingImageUrl) {
+		List<MultipartFile> images = form.getCoreMinistryImages();
+		List<Integer> indexes = form.getCoreMinistryImageIndexes();
+		if (images == null || indexes == null) return existingImageUrl;
+
+		for (int j = 0; j < indexes.size() && j < images.size(); j++) {
+			if (indexes.get(j) == index) {
+				MultipartFile file = images.get(j);
+				if (file != null && !file.isEmpty()) {
+					return awsS3Service.uploadFile(file, buildKey(form.getType(), "core" + index, file));
+				}
+			}
+		}
+		return existingImageUrl;
+	}
+
+	private List<CoreMinistryInput> parseCoreMinistries(String json) {
+		if (json == null || json.isBlank()) return new ArrayList<>();
+		try {
+			return objectMapper.readValue(json, new TypeReference<>() {});
+		} catch (Exception e) {
+			throw new EducationException(EducationExceptionCode.INVALID_CORE_MINISTRIES);
+		}
+	}
+
+	private Integer parseOrder(String order) {
+		if (order == null || order.isBlank()) return null;
+		try {
+			return Integer.parseInt(order.trim());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private String buildKey(String type, String prefix, MultipartFile file) {
+		String now = LocalDateTime.now().format(FORMATTER);
+		String ext = FileUtils.extractExtension(file.getOriginalFilename());
+		return "education/" + type + "/" + prefix + "_" + now + "_" + System.nanoTime() + ext;
+	}
+}

--- a/src/main/java/org/example/luvbackend/service/HomeWorshipService.java
+++ b/src/main/java/org/example/luvbackend/service/HomeWorshipService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.common.util.FileUtils;
 import org.example.luvbackend.dto.aws.S3Directory;
 import org.example.luvbackend.dto.homeworship.CommentCreateForm;
 import org.example.luvbackend.dto.homeworship.CommentDeleteForm;
@@ -147,17 +148,10 @@ public class HomeWorshipService {
 		List<String> keys = new ArrayList<>();
 		int index = startIndex;
 		for (MultipartFile file : files) {
-			keys.add(String.format("homeworships/%s/%s/%02d.%s", date, uuid, index++, getExtension(file)));
+			keys.add(String.format("homeworships/%s/%s/%02d%s", date, uuid, index++,
+				FileUtils.extractExtension(file.getOriginalFilename())));
 		}
 		return keys;
-	}
-
-	private String getExtension(MultipartFile file) {
-		String original = file.getOriginalFilename();
-		if (original != null && original.contains(".")) {
-			return original.substring(original.lastIndexOf('.') + 1).toLowerCase();
-		}
-		return "jpg";
 	}
 
 	private void verifyPassword(String rawPassword, String encodedPassword) {

--- a/src/main/java/org/example/luvbackend/service/LeadershipService.java
+++ b/src/main/java/org/example/luvbackend/service/LeadershipService.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.common.util.FileUtils;
 import org.example.luvbackend.dto.leadership.LeadershipForm;
 import org.example.luvbackend.dto.leadership.LeadershipResponseDto;
 import org.example.luvbackend.entity.leadership.Leadership;
@@ -103,10 +104,8 @@ public class LeadershipService {
 	}
 
 	private String buildS3Key(String tabType, String name, MultipartFile file) {
-		String original = file.getOriginalFilename();
 		String now = LocalDateTime.now().format(FORMATTER);
-		String ext = (original != null && original.contains("."))
-			? original.substring(original.lastIndexOf(".")) : "";
+		String ext = FileUtils.extractExtension(file.getOriginalFilename());
 		String safeName = (name != null) ? name : "unknown";
 		return "leadership/" + tabType + "/" + safeName + "_" + now + ext;
 	}

--- a/src/main/java/org/example/luvbackend/service/PastorBookService.java
+++ b/src/main/java/org/example/luvbackend/service/PastorBookService.java
@@ -1,6 +1,10 @@
 package org.example.luvbackend.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.example.luvbackend.common.dto.PageResponse;
+import org.example.luvbackend.common.util.FileUtils;
 import org.example.luvbackend.dto.pastorbook.PastorBookForm;
 import org.example.luvbackend.dto.pastorbook.PastorBookResponseDto;
 import org.example.luvbackend.entity.pastorbook.PastorBook;
@@ -51,18 +55,11 @@ public class PastorBookService {
 		return new PastorBookResponseDto(pastorBookRepository.save(pastorBook));
 	}
 
-	// leadership/pastor/pastorBooks/{title}.{ext}
+	// leadership/pastor/senior/books/{제목}_{yyyyMMddHHmmss}.{ext}
 	private String buildKey(MultipartFile file, String title) {
-		String ext = getExtension(file);
-		return String.format("leadership/pastor/senior/books/%s.%s", title, ext);
-	}
-
-	private String getExtension(MultipartFile file) {
-		String original = file.getOriginalFilename();
-		if (original != null && original.contains(".")) {
-			return original.substring(original.lastIndexOf('.') + 1).toLowerCase();
-		}
-		return "png";
+		String ext = FileUtils.extractExtension(file.getOriginalFilename());
+		String uploadedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+		return String.format("leadership/pastor/senior/books/%s_%s%s", FileUtils.sanitize(title), uploadedAt, ext);
 	}
 
 	@Transactional

--- a/src/main/java/org/example/luvbackend/service/PastorProfileImageService.java
+++ b/src/main/java/org/example/luvbackend/service/PastorProfileImageService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import org.example.luvbackend.common.util.FileUtils;
 import org.example.luvbackend.dto.pastorprofileimage.PastorProfileImageForm;
 import org.example.luvbackend.dto.pastorprofileimage.PastorProfileImageResponseDto;
 import org.example.luvbackend.entity.pastorprofileimage.PastorProfileImage;
@@ -51,12 +52,12 @@ public class PastorProfileImageService {
 		String now = LocalDateTime.now().format(FORMATTER);
 		if (hasTop) {
 			if (topUrl != null) awsS3Service.deleteFiles(List.of(topUrl));
-			String ext = getExtension(topImage.getOriginalFilename());
+			String ext = FileUtils.extractExtension(topImage.getOriginalFilename());
 			topUrl = awsS3Service.uploadFile(topImage, DIR + "top-" + now + ext);
 		}
 		if (hasBottom) {
 			if (bottomUrl != null) awsS3Service.deleteFiles(List.of(bottomUrl));
-			String ext = getExtension(bottomImage.getOriginalFilename());
+			String ext = FileUtils.extractExtension(bottomImage.getOriginalFilename());
 			bottomUrl = awsS3Service.uploadFile(bottomImage, DIR + "bottom-" + now + ext);
 		}
 
@@ -68,10 +69,5 @@ public class PastorProfileImageService {
 		}
 
 		return new PastorProfileImageResponseDto(pastorProfileImageRepository.save(profile));
-	}
-
-	private String getExtension(String filename) {
-		if (filename == null || !filename.contains(".")) return "";
-		return filename.substring(filename.lastIndexOf("."));
 	}
 }

--- a/src/main/java/org/example/luvbackend/service/PopupService.java
+++ b/src/main/java/org/example/luvbackend/service/PopupService.java
@@ -1,7 +1,10 @@
 package org.example.luvbackend.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import org.example.luvbackend.common.util.FileUtils;
 import org.example.luvbackend.dto.aws.S3Directory;
 import org.example.luvbackend.dto.popup.PopupResponseDto;
 import org.example.luvbackend.dto.popup.PopupUploadForm;
@@ -44,7 +47,13 @@ public class PopupService {
 		if (image.getSize() > MAX_IMAGE_SIZE) {
 			throw new PopupException(PopupExceptionCode.IMAGE_SIZE_OVER_FORM);
 		}
-		String imageUrl = awsS3Service.uploadFile(image, S3Directory.POPUPS);
+		// 파일명을 "팝업제목_업로드날짜시각.확장자"로 지정 (ex.제목_202606061347.jpg)
+		String uploadedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+
+		String key = S3Directory.POPUPS.getPath() + "/" + FileUtils.sanitize(form.getTitle()) + "_" + uploadedAt
+			+ FileUtils.extractExtension(image.getOriginalFilename());
+
+		String imageUrl = awsS3Service.uploadFile(image, key);
 		Popup popup = Popup.builder()
 			.title(form.getTitle())
 			.isShow(true)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,6 +10,7 @@ spring:
       ## IMAGE 업로드 버킷
       s3:
         bucket: ${AWS_S3_BUCKET}
+        prefix: dev # 버킷 내 환경별 최상위 폴더 (ex. dev/albums/...)
       credentials:
         access-key: ${AWS_S3_ACCESS_KEY}
         secret-key: ${AWS_S3_SECRET_KEY}


### PR DESCRIPTION
## 변경 사항

- AWS S3 개발서버 분류
- 파일 제목/확장자 유틸 생성 및 적용으로 인한 서비스 로직 코드 수정

---

## 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.

---

## 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.

---

## 참고 사항

- 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 교육 콘텐츠와 교육 홈을 위한 새로운 REST API(조회/등록/수정/삭제, 업서트)가 추가되었습니다.
  * 교육 도메인용 S3 경로가 확장되고, 관련 업로드 키 규칙이 적용됩니다.
* **버그 수정**
  * 파일명 정리 및 확장자 추출 방식을 통일해 확장자 누락/비정상 입력에도 기본 확장자가 적용됩니다.
  * 여러 이미지 업로드의 저장 경로 형식이 일관되도록 수정되었습니다.
* **개선**
  * S3 업로드에 환경별 접두어(prefix)와 캐시 제어 정책이 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->